### PR TITLE
Fix pagination nav creation outside of table.

### DIFF
--- a/js/footable.paginate.js
+++ b/js/footable.paginate.js
@@ -98,7 +98,7 @@
             if ($nav.length === 0) {
                 $nav = $(ft.pageInfo.pageNavigation);
                 //if the navigation control is inside another table, then get out
-                if ($nav.parents('table:first') !== $(ft.table)) return;
+                if ($nav.parents('table').length && $nav.parents('table:first') !== $(ft.table)) return;
                 //if we found more than one navigation control, write error to console
                 if ($nav.length > 1 && ft.options.debug === true) console.error('More than one pagination control was found!');
             }


### PR DESCRIPTION
Currently we check to see if the nav's parent is another table element, however, we don't take into account the possibility that the nav does not have a table as a parent.  The way we currently check, it makes the creation of paging navs impossible outside of the context of the FooTable.

This commit provides a simple fix.
